### PR TITLE
Enable JavaFX on Maven.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,20 @@
 					<mainClass>pt.game.App</mainClass>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>pt.game.App</mainClass>
+						</manifest>
+					</archive>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+			</plugin>
         </plugins>
     </build>
     

--- a/pom.xml
+++ b/pom.xml
@@ -13,22 +13,24 @@
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
+	<dependencies>
+	    <dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-controls</artifactId>
+			<version>17-ea+14</version>
+		</dependency>
+	</dependencies>
+
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>
-                                pt.game.App
-                            </mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
+			<plugin>
+				<groupId>org.openjfx</groupId>
+				<artifactId>javafx-maven-plugin</artifactId>
+				<version>0.0.6</version>
+				<configuration>
+					<mainClass>pt.game.App</mainClass>
+				</configuration>
+			</plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
- Enable JavaFX on Maven.
- Add Maven target to build a jar with javafx.

Build a self contained jar file with `mvn assembly:single`.